### PR TITLE
fix: deduplicate session inserts and skip redundant profile upserts

### DIFF
--- a/providers/liff-providers.tsx
+++ b/providers/liff-providers.tsx
@@ -57,12 +57,14 @@ async function signInWithLINE(
     const needsOnboarding = !profile?.age || !profile?.gender;
     if (needsOnboarding) {
       localStorage.removeItem(ONBOARDING_KEY);
-      // Re-create profile row if it was deleted
-      const meta = session.user.user_metadata ?? {};
-      supabase.from("profiles").upsert(
-        { id: session.user.id, display_name: meta.display_name ?? null },
-        { onConflict: "id", ignoreDuplicates: false }
-      ).then();
+      // Re-create profile row only if it was deleted (profile fetch returned null)
+      if (!profile) {
+        const meta = session.user.user_metadata ?? {};
+        supabase.from("profiles").upsert(
+          { id: session.user.id, display_name: meta.display_name ?? null },
+          { onConflict: "id", ignoreDuplicates: true }
+        ).then(({ error }) => { if (error) console.error("[Profile upsert]", error.message); });
+      }
     } else {
       localStorage.setItem(ONBOARDING_KEY, "true");
     }
@@ -131,15 +133,16 @@ async function signInWithLINE(
     };
   }
 
-  // Step 3: Upsert profile + optionally check onboarding — run in parallel
+  // Step 3: Upsert profile (ignoreDuplicates: true so existing profiles aren't overwritten)
+  // + optionally check onboarding — run in parallel
   const upsertPromise = supabase.from("profiles").upsert(
     { id: data.user.id, display_name },
-    { onConflict: "id", ignoreDuplicates: false }
+    { onConflict: "id", ignoreDuplicates: true }
   );
 
   if (onboardingCached) {
     // Don't wait for profile check — fire upsert and return immediately
-    upsertPromise.then();
+    upsertPromise.then(({ error }) => { if (error) console.error("[Profile upsert]", error.message); });
     return { error: null, needsOnboarding: false };
   }
 
@@ -202,12 +205,19 @@ function LIFFProvider({ children }: { children: React.ReactNode }) {
                 liff.logout();
                 setIsLoggedIn(false);
               } else {
-                // Record session for DAU tracking (fire and forget)
+                // Record session for DAU tracking (once per day per user)
                 const supabase = getSupabase();
                 supabase.auth.getSession().then(({ data }) => {
-                  if (data?.session?.user) {
-                    supabase.from("sessions").insert({ user_id: data.session.user.id }).then();
-                  }
+                  if (!data?.session?.user) return;
+                  const uid = data.session.user.id;
+                  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+                  const sessionKey = `session_recorded_${today}`;
+                  if (localStorage.getItem(sessionKey)) return; // already recorded today
+                  supabase.from("sessions").insert({ user_id: uid })
+                    .then(({ error }) => {
+                      if (!error) localStorage.setItem(sessionKey, "1");
+                      else console.error("[Session insert]", error.message);
+                    });
                 });
               }
               setNeedsOnboarding(needsOnboarding);


### PR DESCRIPTION
## Summary
- **Session INSERT deduplication:** Uses a `localStorage` key (`session_recorded_YYYY-MM-DD`) to ensure only one session row is inserted per user per day, eliminating write amplification under concurrent load
- **Profile UPSERT optimization:** Changed to `ignoreDuplicates: true` so existing profiles aren't overwritten on every login. On the fast path, only upserts if the profile row is actually missing (null), not just missing onboarding fields
- **Error logging:** All fire-and-forget `.then()` calls now log errors instead of silently swallowing them

Fixes https://github.com/SopShafety/thai-book-buddy/issues/3
Fixes https://github.com/SopShafety/thai-book-buddy/issues/4

## Test plan
- [ ] Login flow still works — profile is created on first login
- [ ] Refreshing the page does NOT insert a duplicate session row
- [ ] Opening the app the next day inserts a new session row
- [ ] Onboarding flow still triggers when profile has no age/gender
- [ ] `completeProfile()` still updates age/gender correctly