### PR TITLE
perf: replace unbounded book query with server-side aggregation

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -107,19 +107,19 @@ export default function BrowsePage() {
     async function loadUserData() {
       try {
         const supabase = getSupabase();
-        const [{ data: { session } }, { data: sels }, { data: books }] = await Promise.all([
+        const [{ data: { session } }, { data: sels }, { data: counts }] = await Promise.all([
           supabase.auth.getSession(),
           supabase.from("user_selections").select("publisher_id"),
-          supabase.from("user_books").select("publisher_id"),
+          supabase.rpc("get_my_book_counts"),
         ]);
         if (session?.user) setUserId(session.user.id);
         if (sels) setSelectedIds(new Set(sels.map((s: { publisher_id: string }) => s.publisher_id)));
-        if (books) {
-          const counts = new Map<string, number>();
-          for (const b of books as { publisher_id: string }[]) {
-            counts.set(b.publisher_id, (counts.get(b.publisher_id) ?? 0) + 1);
+        if (counts) {
+          const map = new Map<string, number>();
+          for (const c of counts as { publisher_id: string; count: number }[]) {
+            map.set(c.publisher_id, Number(c.count));
           }
-          setBookCounts(counts);
+          setBookCounts(map);
         }
       } catch {
         // Non-critical: list still works, user just won't see their selections

--- a/supabase/migrations/20260329000000_add_book_counts_rpc.sql
+++ b/supabase/migrations/20260329000000_add_book_counts_rpc.sql
@@ -1,0 +1,13 @@
+-- Returns book counts grouped by publisher_id for the current user.
+-- Replaces the unbounded SELECT on user_books in the browse page.
+create or replace function get_my_book_counts()
+returns table(publisher_id uuid, count bigint)
+language sql
+security invoker
+stable
+as $$
+  select publisher_id, count(*) as count
+  from user_books
+  where user_id = auth.uid()
+  group by publisher_id;
+$$;


### PR DESCRIPTION
## Summary
- Adds `get_my_book_counts()` RPC that returns `publisher_id, count(*)` grouped by publisher for the current user
- Replaces the unbounded `SELECT publisher_id FROM user_books` on the browse page that fetched **all** book rows and counted them client-side in a JavaScript loop
- The `user_selections` query (one row per saved publisher) is kept as-is since it's already bounded

**Before:** A user with 1,000 books → 1,000 rows fetched, transferred, and looped over on every page load
**After:** Same user → ~10-20 rows returned (one per publisher with a count)

Fixes https://github.com/SopShafety/thai-book-buddy/issues/5

## Test plan
- [ ] Browse page still shows correct book counts per publisher
- [ ] Browse page still shows correct selection state (bookmarked publishers)
- [ ] Run `get_my_book_counts()` RPC migration on Supabase
- [ ] Verify query plan uses index on `user_books(user_id)` via `EXPLAIN`