### PR TITLE
fix: admin rate limiting and dev auth bypass guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Thai Book Buddy — a LINE LIFF web app for Thai book fair visitors to track publishers, wishlist books, and find booth locations.
+
+**Stack**: Next.js 16 (App Router) + React 19 + TypeScript + Tailwind CSS v4 + Supabase + LINE LIFF
+
+## Commands
+
+```bash
+npm run dev          # Dev server at localhost:3000
+npm run build        # Production build (also type-checks)
+npm run lint         # ESLint
+supabase start       # Local Supabase (run from repo root)
+supabase db push     # Deploy migrations to cloud
+```
+
+No test framework is configured.
+
+## Architecture
+
+### Auth Flow (spans multiple files)
+
+1. `providers/liff-providers.tsx` — LIFF SDK init (10s timeout) → LINE login → call Supabase edge function `auth-line` → exchange token_hash via `verifyOtp` → check profile for onboarding
+2. `supabase/functions/auth-line/index.ts` — Deno edge function that verifies LINE access token, creates/finds Supabase user, returns magic-link token_hash
+3. Dev bypass: `NODE_ENV === "development" && NEXT_PUBLIC_DEV_BYPASS_AUTH === "true"` skips LIFF entirely (checked in liff-providers.tsx and my-list/page.tsx)
+
+### Pages
+
+All pages are `"use client"` (LIFF + Supabase auth dependency). React Compiler is enabled (`next.config.ts`) for automatic memoization.
+
+- `/` — Login gate + onboarding form
+- `/browse` — Publisher list with search/zone filter, wishlist toggle
+- `/map` — Zoomable SVG booth map
+- `/my-list` — Wishlist detail: books per publisher, purchase tracking, notes
+- `/admin` — Analytics dashboard, password-gated via `x-admin-password` header checked against `ADMIN_PASSWORD` env var
+
+### API Routes
+
+- `GET /api/publishers` — All publishers + booths (in-memory cache, 1hr TTL)
+- `GET /api/admin/data` — Dashboard analytics (rate-limited, admin-only)
+- `GET /api/admin/publisher/[id]` — Publisher detail + demographics (rate-limited, admin-only)
+- Admin rate limiting: `app/api/admin/rate-limit.ts` — 5 failed attempts per IP per 5 minutes
+
+### Database (Supabase PostgreSQL)
+
+Core tables: `profiles` (age, gender, display_name), `publishers` (name_th, name_en, category[]), `booths` (zone, booth_number, x/y coords), `user_selections` (wishlist), `user_books` (title, price, is_purchased), `sessions` (DAU tracking).
+
+RPC functions (defined in migrations): `admin_get_publisher_stats`, `admin_get_dau`, `admin_get_top_books`, `admin_get_global_demographics`, `admin_get_publisher_demographics`.
+
+RLS: Public read for publishers/booths; users can only modify their own data.
+
+### State Management
+
+- `LIFFContext` (providers/liff-providers.tsx) — auth state, LIFF object, login status, onboarding flag
+- Each page manages its own local state (no state management library)
+- localStorage: onboarding flag, publishers cache (1hr), dismissals
+- `utils/supabase.ts` — singleton Supabase client
+
+## Environment Variables
+
+**Required** (`.env.local`):
+- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase client config
+- `SUPABASE_SERVICE_ROLE_KEY` — Admin key for API routes (server-only)
+- `NEXT_PUBLIC_LIFF_ID` — LINE LIFF app ID
+- `ADMIN_PASSWORD` — Password for admin API endpoints
+
+**Optional**:
+- `NEXT_PUBLIC_DEV_BYPASS_AUTH` — Skip LIFF auth in development
+- `NEXT_PUBLIC_DONATE_BANNER_ENABLED` — Show donation banner
+
+## Workflow
+
+Before starting any new work (feature, bugfix, etc.), always create a new git worktree with a new branch. Never work directly on `main`.
+
+## Conventions
+
+- **Timeouts**: All critical async ops use `withTimeout(promise, ms, msg)` helper (10-15s). LIFF init has a separate 10s `Promise.race`.
+- **Preview mode**: `?preview=1` query string on `/browse` and `/map` loads mock data without auth.
+- **Inline Tailwind colors**: Uses literal hex values in className (e.g. `text-[#c4855a]`), not theme tokens.
+- **Thai text**: UI is primarily Thai. Publisher names have both `name_th` (required) and `name_en` (nullable).
+- **Optimistic updates**: Wishlist toggles and book deletions update UI immediately, then write to DB. Undo via toast with 4s timer.
+- **Fonts**: Literata (serif headings), Plus Jakarta Sans (numbers), Sarabun (Thai body text) — loaded via `next/font` in `app/layout.tsx`.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -149,12 +149,12 @@ export default function AdminPage() {
     const json = await res.json();
     setData(json);
     setAuthed(true);
-    localStorage.setItem("admin_pw", pw);
+    sessionStorage.setItem("admin_pw", pw);
   }, []);
 
   // Auto-try stored password on mount
   useEffect(() => {
-    const stored = localStorage.getItem("admin_pw");
+    const stored = sessionStorage.getItem("admin_pw");
     if (stored) {
       setPassword(stored);
       fetchData(stored);
@@ -316,7 +316,7 @@ export default function AdminPage() {
             </button>
             <button
               onClick={() => {
-                localStorage.removeItem("admin_pw");
+                sessionStorage.removeItem("admin_pw");
                 setAuthed(false);
                 setData(null);
                 setPassword("");

--- a/app/api/admin/data/route.ts
+++ b/app/api/admin/data/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { checkAdminAuth } from "../rate-limit";
 
 function adminClient() {
   return createClient(
@@ -9,9 +10,8 @@ function adminClient() {
 }
 
 export async function GET(req: NextRequest) {
-  if (req.headers.get("x-admin-password") !== process.env.ADMIN_PASSWORD) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const denied = checkAdminAuth(req);
+  if (denied) return denied;
 
   const supabase = adminClient();
 

--- a/app/api/admin/publisher/[id]/route.ts
+++ b/app/api/admin/publisher/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { checkAdminAuth } from "../../rate-limit";
 
 function adminClient() {
   return createClient(
@@ -12,9 +13,8 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  if (req.headers.get("x-admin-password") !== process.env.ADMIN_PASSWORD) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const denied = checkAdminAuth(req);
+  if (denied) return denied;
 
   const { id: publisherId } = await context.params;
   const supabase = adminClient();

--- a/app/api/admin/rate-limit.ts
+++ b/app/api/admin/rate-limit.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_ATTEMPTS = 5;
+const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+interface Entry {
+  count: number;
+  firstAttempt: number;
+}
+
+const failedAttempts = new Map<string, Entry>();
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+/**
+ * Check admin password with rate limiting on failed attempts.
+ * Returns a 401/429 Response if denied, or null if authorized.
+ */
+export function checkAdminAuth(req: NextRequest): NextResponse | null {
+  const ip = getClientIp(req);
+  const now = Date.now();
+
+  // Clean up expired entry
+  const entry = failedAttempts.get(ip);
+  if (entry && now - entry.firstAttempt > WINDOW_MS) {
+    failedAttempts.delete(ip);
+  }
+
+  // Check if locked out
+  const current = failedAttempts.get(ip);
+  if (current && current.count >= MAX_ATTEMPTS) {
+    const retryAfter = Math.ceil(
+      (WINDOW_MS - (now - current.firstAttempt)) / 1000
+    );
+    return NextResponse.json(
+      { error: "Too many failed attempts. Try again later." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.max(retryAfter, 1)) },
+      }
+    );
+  }
+
+  // Check password
+  if (req.headers.get("x-admin-password") !== process.env.ADMIN_PASSWORD) {
+    const existing = failedAttempts.get(ip);
+    if (existing) {
+      existing.count++;
+    } else {
+      failedAttempts.set(ip, { count: 1, firstAttempt: now });
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Success — clear failed attempts for this IP
+  failedAttempts.delete(ip);
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import { Literata, Plus_Jakarta_Sans, Sarabun } from "next/font/google";
 import "./globals.css";
 import { LIFFProvider } from "../providers/liff-providers";
@@ -20,14 +21,16 @@ export const viewport: Viewport = {
   viewportFit: "cover",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = (await headers()).get("x-nonce") ?? "";
+
   return (
     <html lang="en">
-      <body className={`${literata.variable} ${jakarta.variable} ${sarabun.variable}`}>
+      <body className={`${literata.variable} ${jakarta.variable} ${sarabun.variable}`} nonce={nonce}>
         <LIFFProvider>{children}</LIFFProvider>
       </body>
     </html>

--- a/app/my-list/page.tsx
+++ b/app/my-list/page.tsx
@@ -65,7 +65,7 @@ export default function MyListPage() {
     if (!isLoggedIn) return;
 
     // Dev bypass: use mock data to preview UI without a Supabase session
-    if (process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH === "true") {
+    if (process.env.NODE_ENV === "development" && process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH === "true") {
       setUserId("dev-user");
       setPublishers([
         { id: "p1", name_th: "สำนักพิมพ์แสงดาว", name_en: "Sangdao Publishing", booths: [{ zone: "A", booth_number: "A01" }] },
@@ -234,7 +234,7 @@ export default function MyListPage() {
       else next.delete(publisherId);
       return next;
     });
-    if (process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH !== "true" && userId) {
+    if (!(process.env.NODE_ENV === "development" && process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH === "true") && userId) {
       const supabase = getSupabase();
       await supabase.from("user_selections").update({ note }).eq("user_id", userId).eq("publisher_id", publisherId);
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+
+  const csp = [
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' https://*.line-scdn.net`,
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src 'self' data: https://*.line-scdn.net`,
+    `font-src 'self' data:`,
+    `connect-src 'self' https://*.supabase.co https://*.line.me https://*.line-scdn.net`,
+    `frame-src https://liff.line.me`,
+    `frame-ancestors 'self' https://*.line.me`,
+  ].join("; ");
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("Content-Security-Policy", csp);
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("X-Frame-Options", "SAMEORIGIN");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Match all paths except static files and images
+    { source: "/((?!_next/static|_next/image|favicon.ico).*)" },
+  ],
+};

--- a/providers/liff-providers.tsx
+++ b/providers/liff-providers.tsx
@@ -168,7 +168,7 @@ function LIFFProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     // Dev bypass: skip LIFF entirely, force logged-in state
-    if (process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH === "true") {
+    if (process.env.NODE_ENV === "development" && process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH === "true") {
       setIsLoggedIn(true);
       setIsLoading(false);
       return;

--- a/providers/liff-providers.tsx
+++ b/providers/liff-providers.tsx
@@ -62,7 +62,7 @@ async function signInWithLINE(
       supabase.from("profiles").upsert(
         { id: session.user.id, display_name: meta.display_name ?? null },
         { onConflict: "id", ignoreDuplicates: false }
-      ).then();
+      ).then(({ error }) => { if (error) console.error("[DB] Profile re-create failed:", error.message); });
     } else {
       localStorage.setItem(ONBOARDING_KEY, "true");
     }
@@ -139,7 +139,7 @@ async function signInWithLINE(
 
   if (onboardingCached) {
     // Don't wait for profile check — fire upsert and return immediately
-    upsertPromise.then();
+    upsertPromise.then(({ error }) => { if (error) console.error("[DB] Profile upsert failed:", error.message); });
     return { error: null, needsOnboarding: false };
   }
 
@@ -206,7 +206,8 @@ function LIFFProvider({ children }: { children: React.ReactNode }) {
                 const supabase = getSupabase();
                 supabase.auth.getSession().then(({ data }) => {
                   if (data?.session?.user) {
-                    supabase.from("sessions").insert({ user_id: data.session.user.id }).then();
+                    supabase.from("sessions").insert({ user_id: data.session.user.id })
+                      .then(({ error }) => { if (error) console.error("[DB] Session insert failed:", error.message); });
                   }
                 });
               }

--- a/supabase/functions/auth-line/index.ts
+++ b/supabase/functions/auth-line/index.ts
@@ -24,9 +24,15 @@ const ALLOWED_ORIGINS = [
 
 function getCorsHeaders(req: Request): Record<string, string> {
   const origin = req.headers.get("origin") ?? "";
-  const allowedOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  if (!ALLOWED_ORIGINS.includes(origin)) {
+    return {
+      "Access-Control-Allow-Origin": "null",
+      "Access-Control-Allow-Headers":
+        "authorization, x-client-info, apikey, content-type",
+    };
+  }
   return {
-    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Headers":
       "authorization, x-client-info, apikey, content-type",
   };

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,6 @@
     {
       "source": "/(.*)",
       "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.line-scdn.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.line-scdn.net; font-src 'self' data:; connect-src 'self' https://eoyiqojukzbjgayabcth.supabase.co https://*.line.me https://*.line-scdn.net; frame-src https://liff.line.me; frame-ancestors 'self' https://*.line.me"
-        },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }


### PR DESCRIPTION
## Summary
- **Closes #1**: Move admin password storage from `localStorage` to `sessionStorage` — scoped to browser tab, cleared on close
- **Closes #2**: Add IP-based rate limiting (5 failed attempts / 5 min) to admin API endpoints
- **Closes #6**: Add error logging to fire-and-forget `.then()` calls on profile upsert and session insert
- **Closes #7**: Reject CORS requests from unknown origins instead of falling back to production origin
- **Closes #8**: Add `NODE_ENV === "development"` guard to dev auth bypass so it's dead code in production
- **Closes #16**: Replace `'unsafe-inline'` in CSP `script-src` with per-request nonce via Next.js middleware
- **Closes #22**: Replace hardcoded Supabase project ID in CSP with `*.supabase.co` wildcard

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Confirm dev bypass works locally (`NODE_ENV=development` + `NEXT_PUBLIC_DEV_BYPASS_AUTH=true`)
- [ ] Confirm dev bypass is inactive in production build
- [ ] Test admin login: password persists within tab, cleared on tab close
- [ ] Test admin endpoints: 5 wrong passwords → 429 with Retry-After header
- [ ] Test CORS: requests from unlisted origins get `Access-Control-Allow-Origin: null`
- [ ] Test CSP: verify nonce is present on inline scripts, no `unsafe-inline` in script-src
- [ ] Test LIFF SDK still loads and functions correctly with nonce-based CSP
- [ ] Trigger a DB error (e.g. disconnect Supabase) and verify errors appear in console for profile upsert and session insert