### PR TITLE
fix: resolve all high-priority issues (#9, #10, #11, #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ RLS: Public read for publishers/booths; users can only modify their own data.
 
 Before starting any new work (feature, bugfix, etc.), always create a new git worktree with a new branch. Never work directly on `main`.
 
+If this is a forked repo, when unsure about something (PR target, push destination, whether to pull upstream first, etc.), ask — don't assume.
+
 ## Conventions
 
 - **Timeouts**: All critical async ops use `withTimeout(promise, ms, msg)` helper (10-15s). LIFF init has a separate 10s `Promise.race`.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -171,12 +171,19 @@ export default function AdminPage() {
   async function openDetail(pub: PublisherStat) {
     setDetail({ id: pub.id, name_th: pub.name_th, saves: pub.saves, books_added: pub.books_added, demographics: [], books: [] });
     setDetailLoading(true);
-    const res = await fetch(`/api/admin/publisher/${pub.id}`, {
-      headers: { "x-admin-password": password },
-    });
-    const json = await res.json();
-    setDetail({ id: pub.id, saves: pub.saves, books_added: pub.books_added, ...json });
-    setDetailLoading(false);
+    try {
+      const res = await fetch(`/api/admin/publisher/${pub.id}`, {
+        headers: { "x-admin-password": password },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setDetail({ id: pub.id, saves: pub.saves, books_added: pub.books_added, ...json });
+    } catch {
+      setDetail(null);
+      alert("โหลดข้อมูลสำนักพิมพ์ไม่สำเร็จ กรุณาลองใหม่");
+    } finally {
+      setDetailLoading(false);
+    }
   }
 
   const sorted = data

--- a/app/api/admin/data/route.ts
+++ b/app/api/admin/data/route.ts
@@ -9,9 +9,16 @@ function adminClient() {
   );
 }
 
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+let cachedResult: { data: unknown; timestamp: number } | null = null;
+
 export async function GET(req: NextRequest) {
   const denied = checkAdminAuth(req);
   if (denied) return denied;
+
+  if (cachedResult && Date.now() - cachedResult.timestamp < CACHE_TTL_MS) {
+    return NextResponse.json(cachedResult.data);
+  }
 
   const supabase = adminClient();
 
@@ -94,5 +101,6 @@ export async function GET(req: NextRequest) {
   }));
 
   const result = { publishers: publisherStats, dau, totals, demographics, top_books };
+  cachedResult = { data: result, timestamp: Date.now() };
   return NextResponse.json(result);
 }

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -166,6 +166,7 @@ export default function BrowsePage() {
 
   const doRemoveOrAdd = useCallback(async (publisherId: string, isSelected: boolean) => {
     togglingRef.current.add(publisherId);
+    const prevSelectedIds = new Set(selectedIds);
     setSelectedIds((prev) => {
       const next = new Set(prev);
       isSelected ? next.delete(publisherId) : next.add(publisherId);
@@ -176,19 +177,29 @@ export default function BrowsePage() {
       setToast("เพิ่มในรายการแล้ว");
       toastTimer.current = setTimeout(() => setToast(null), 2500);
     }
-    const supabase = getSupabase();
-    if (isSelected) {
-      await Promise.all([
-        supabase.from("user_selections").delete()
-          .eq("user_id", userId!).eq("publisher_id", publisherId),
-        supabase.from("user_books").delete()
-          .eq("user_id", userId!).eq("publisher_id", publisherId),
-      ]);
-    } else {
-      await supabase.from("user_selections").insert({ user_id: userId!, publisher_id: publisherId });
+    try {
+      const supabase = getSupabase();
+      if (isSelected) {
+        const [selRes, bookRes] = await Promise.all([
+          supabase.from("user_selections").delete()
+            .eq("user_id", userId!).eq("publisher_id", publisherId),
+          supabase.from("user_books").delete()
+            .eq("user_id", userId!).eq("publisher_id", publisherId),
+        ]);
+        if (selRes.error || bookRes.error) throw new Error("delete failed");
+      } else {
+        const { error } = await supabase.from("user_selections").insert({ user_id: userId!, publisher_id: publisherId });
+        if (error) throw new Error("insert failed");
+      }
+    } catch {
+      setSelectedIds(prevSelectedIds);
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      setToast("เกิดข้อผิดพลาด กรุณาลองใหม่");
+      toastTimer.current = setTimeout(() => setToast(null), 3000);
+    } finally {
+      togglingRef.current.delete(publisherId);
     }
-    togglingRef.current.delete(publisherId);
-  }, [userId]); // toastTimer is a stable ref — intentionally not listed
+  }, [userId, selectedIds]); // toastTimer is a stable ref — intentionally not listed
 
   const handleToggle = useCallback(async (publisherId: string) => {
     if (!userId || togglingRef.current.has(publisherId)) return;

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
 
   const csp = [

--- a/supabase/migrations/20260402000000_add_profiles_demographics_index.sql
+++ b/supabase/migrations/20260402000000_add_profiles_demographics_index.sql
@@ -1,0 +1,6 @@
+-- Add composite partial index on profiles for demographic queries.
+-- Used by admin_get_global_demographics() and admin_get_publisher_demographics()
+-- which filter on age IS NOT NULL AND gender IS NOT NULL and GROUP BY age, gender.
+CREATE INDEX IF NOT EXISTS idx_profiles_age_gender
+  ON profiles(age, gender)
+  WHERE age IS NOT NULL AND gender IS NOT NULL;


### PR DESCRIPTION
## Summary

- **#9** — Add error handling and rollback to optimistic delete on browse page. Supabase errors are now caught, the UI rolls back to the previous state, and an error toast is shown.
- **#10** — Prevent admin detail modal from hanging on fetch error. Added try/catch with `res.ok` check and a `finally` block so the loading spinner always stops.
- **#11** — Add 5-minute server-side cache to admin data API to reduce DB load from repeated dashboard visits during peak traffic.
- **#12** — Add composite partial index on `profiles(age, gender)` for demographic queries used by the admin dashboard.

Closes #9
Closes #10
Closes #11
Closes #12

## Test plan

- [ ] Browse page: toggle a publisher off while offline/with network error — verify UI rolls back and error toast appears
- [ ] Admin dashboard: click a publisher row when API returns 500 — verify modal closes with alert instead of infinite spinner
- [ ] Admin dashboard: load twice within 5 minutes — verify second load is near-instant (cached)
- [ ] Run migration on staging and verify `idx_profiles_age_gender` index exists via `\di` in psql