### PR TITLE
fix: accessibility improvements — dialogs, ARIA, landmarks

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 
 type PublisherStat = {
   id: string;
@@ -209,6 +210,11 @@ export default function AdminPage() {
   function sortIndicator(key: SortKey) {
     if (sortKey !== key) return null;
     return sortDir === "desc" ? " ↓" : " ↑";
+  }
+
+  function ariaSort(key: SortKey): "ascending" | "descending" | "none" {
+    if (sortKey !== key) return "none";
+    return sortDir === "asc" ? "ascending" : "descending";
   }
 
   function exportLeaderboard() {
@@ -496,24 +502,28 @@ export default function AdminPage() {
                     <th
                       className="text-left px-5 py-3 text-xs text-gray-400 font-medium cursor-pointer select-none hover:text-gray-600"
                       onClick={() => toggleSort("name_th")}
+                      aria-sort={ariaSort("name_th")}
                     >
                       Publisher{sortIndicator("name_th")}
                     </th>
                     <th
                       className="text-right px-5 py-3 text-xs text-gray-400 font-medium cursor-pointer select-none hover:text-gray-600"
                       onClick={() => toggleSort("saves")}
+                      aria-sort={ariaSort("saves")}
                     >
                       Wishlisted{sortIndicator("saves")}
                     </th>
                     <th
                       className="text-right px-5 py-3 text-xs text-gray-400 font-medium cursor-pointer select-none hover:text-gray-600"
                       onClick={() => toggleSort("books_added")}
+                      aria-sort={ariaSort("books_added")}
                     >
                       Books Added{sortIndicator("books_added")}
                     </th>
                     <th
                       className="text-right px-5 py-3 text-xs text-gray-400 font-medium cursor-pointer select-none hover:text-gray-600"
                       onClick={() => toggleSort("books_per_saver")}
+                      aria-sort={ariaSort("books_per_saver")}
                     >
                       Books/Saver{sortIndicator("books_per_saver")}
                     </th>
@@ -552,21 +562,16 @@ export default function AdminPage() {
       </div>
 
       {/* Publisher detail modal */}
-      {detail && (
-        <div
-          className="fixed inset-0 bg-black/40 z-50 flex items-end sm:items-center justify-center sm:p-4"
-          onClick={() => setDetail(null)}
-        >
-          <div
-            className="bg-white w-full sm:max-w-lg sm:rounded-2xl rounded-t-2xl max-h-[85vh] flex flex-col"
-            onClick={(e) => e.stopPropagation()}
-          >
+      <Dialog open={!!detail} onClose={() => setDetail(null)} className="relative z-50">
+        <DialogBackdrop className="fixed inset-0 bg-black/40" />
+        <div className="fixed inset-0 flex items-end sm:items-center justify-center sm:p-4">
+          <DialogPanel className="bg-white w-full sm:max-w-lg sm:rounded-2xl rounded-t-2xl max-h-[85vh] flex flex-col">
             {/* Modal header */}
             <div className="flex items-start justify-between px-6 py-4 border-b border-gray-100 shrink-0">
               <div>
-                <h2 className="font-bold text-gray-800">{detail.name_th}</h2>
+                <DialogTitle className="font-bold text-gray-800">{detail?.name_th}</DialogTitle>
                 <p className="text-xs text-gray-400 mt-0.5">
-                  {detail.saves} wishlisted · {detail.books_added} books added
+                  {detail?.saves} wishlisted · {detail?.books_added} books added
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -578,6 +583,7 @@ export default function AdminPage() {
                 </button>
                 <button
                   onClick={() => setDetail(null)}
+                  aria-label="ปิด"
                   className="text-gray-400 hover:text-gray-600 text-2xl leading-none ml-1"
                 >
                   ×
@@ -603,7 +609,7 @@ export default function AdminPage() {
 
                     const ageMap = new Map<string, number>();
                     const genderMap = new Map<string, number>();
-                    for (const d of detail.demographics) {
+                    for (const d of detail?.demographics ?? []) {
                       ageMap.set(d.age, (ageMap.get(d.age) ?? 0) + d.count);
                       genderMap.set(d.gender, (genderMap.get(d.gender) ?? 0) + d.count);
                     }
@@ -662,13 +668,13 @@ export default function AdminPage() {
                   })()}
 
                   {/* Book titles */}
-                  {detail.books.length > 0 && (
+                  {(detail?.books.length ?? 0) > 0 && (
                     <div>
                       <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
-                        Books Added by Users ({detail.books.length} titles)
+                        Books Added by Users ({detail?.books.length} titles)
                       </h3>
                       <div className="flex flex-col">
-                        {detail.books.map((b, i) => (
+                        {detail?.books.map((b, i) => (
                           <div
                             key={i}
                             className="flex items-center justify-between py-2 border-b border-gray-50"
@@ -685,8 +691,8 @@ export default function AdminPage() {
                     </div>
                   )}
 
-                  {detail.demographics.length === 0 &&
-                    detail.books.length === 0 && (
+                  {(detail?.demographics.length === 0) &&
+                    (detail?.books.length === 0) && (
                       <p className="text-sm text-gray-400 text-center py-4">
                         ยังไม่มีข้อมูลเพิ่มเติม
                       </p>
@@ -694,9 +700,9 @@ export default function AdminPage() {
                 </div>
               )}
             </div>
-          </div>
+          </DialogPanel>
         </div>
-      )}
+      </Dialog>
     </div>
   );
 }

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 import { Bookmark, Check, HandHeart } from "lucide-react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -236,12 +237,14 @@ export default function BrowsePage() {
           </div>
 
           {/* Category filter */}
-          <div className="flex gap-[8px] px-[16px] pb-[12px] overflow-x-auto no-scrollbar">
+          <div role="tablist" aria-label="กรองโซน" className="flex gap-[8px] px-[16px] pb-[12px] overflow-x-auto no-scrollbar">
             {categories.map((cat) => {
               const active = activeZone === cat;
               return (
                 <button
                   key={cat}
+                  role="tab"
+                  aria-selected={active}
                   onClick={() => setActiveZone(cat)}
                   className={`shrink-0 px-[12px] py-[4px] rounded-[20px] text-[14px] font-[family-name:var(--font-sarabun)] transition-all ${
                     active
@@ -353,42 +356,39 @@ export default function BrowsePage() {
         </div>
       )}
 
-      {confirmPublisherId && (() => {
-        const pub = publishers.find((p) => p.id === confirmPublisherId);
-        const count = bookCounts.get(confirmPublisherId) ?? 0;
-        return (
-          <div className="absolute inset-0 z-30 flex items-end justify-center bg-black/40" onClick={() => setConfirmPublisherId(null)}>
-            <div className="w-full bg-[#fafaf8] rounded-t-[24px] p-[24px] flex flex-col gap-[16px]" onClick={(e) => e.stopPropagation()}>
-              <div className="flex flex-col gap-[8px]">
-                <p className="font-[family-name:var(--font-sarabun)] font-semibold text-[18px] text-[#3d2b1a]">
-                  ลบสำนักพิมพ์นี้?
-                </p>
-                <p className="font-[family-name:var(--font-sarabun)] font-light text-[14px] text-[#6a7282]">
-                  {pub?.name_th} มีหนังสือในรายการ {count} เล่ม หากลบสำนักพิมพ์นี้ หนังสือทั้งหมดจะถูกลบออกด้วย
-                </p>
-              </div>
-              <div className="flex gap-[8px]">
-                <button
-                  onClick={async () => {
-                    const id = confirmPublisherId;
-                    setConfirmPublisherId(null);
-                    await doRemoveOrAdd(id, true);
-                  }}
-                  className="flex-1 h-[48px] rounded-[12px] bg-[#c4855a] font-[family-name:var(--font-sarabun)] text-[16px] text-white"
-                >
-                  ลบออก
-                </button>
-                <button
-                  onClick={() => setConfirmPublisherId(null)}
-                  className="flex-1 h-[48px] rounded-[12px] border border-[#e2c9a6] bg-[#fafaf8] font-[family-name:var(--font-sarabun)] text-[16px] text-[#c4855a]"
-                >
-                  ยกเลิก
-                </button>
-              </div>
+      <Dialog open={!!confirmPublisherId} onClose={() => setConfirmPublisherId(null)} className="relative z-30">
+        <DialogBackdrop className="fixed inset-0 bg-black/40" />
+        <div className="fixed inset-0 flex items-end justify-center">
+          <DialogPanel className="w-full bg-[#fafaf8] rounded-t-[24px] p-[24px] flex flex-col gap-[16px]">
+            <div className="flex flex-col gap-[8px]">
+              <DialogTitle className="font-[family-name:var(--font-sarabun)] font-semibold text-[18px] text-[#3d2b1a]">
+                ลบสำนักพิมพ์นี้?
+              </DialogTitle>
+              <p className="font-[family-name:var(--font-sarabun)] font-light text-[14px] text-[#6a7282]">
+                {publishers.find((p) => p.id === confirmPublisherId)?.name_th} มีหนังสือในรายการ {bookCounts.get(confirmPublisherId!) ?? 0} เล่ม หากลบสำนักพิมพ์นี้ หนังสือทั้งหมดจะถูกลบออกด้วย
+              </p>
             </div>
-          </div>
-        );
-      })()}
+            <div className="flex gap-[8px]">
+              <button
+                onClick={async () => {
+                  const id = confirmPublisherId!;
+                  setConfirmPublisherId(null);
+                  await doRemoveOrAdd(id, true);
+                }}
+                className="flex-1 h-[48px] rounded-[12px] bg-[#c4855a] font-[family-name:var(--font-sarabun)] text-[16px] text-white"
+              >
+                ลบออก
+              </button>
+              <button
+                onClick={() => setConfirmPublisherId(null)}
+                className="flex-1 h-[48px] rounded-[12px] border border-[#e2c9a6] bg-[#fafaf8] font-[family-name:var(--font-sarabun)] text-[16px] text-[#c4855a]"
+              >
+                ยกเลิก
+              </button>
+            </div>
+          </DialogPanel>
+        </div>
+      </Dialog>
 
       <BottomNav />
       <BookFairReminderModal isOpen={showReminder} onClose={() => setShowReminder(false)} />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={`${literata.variable} ${jakarta.variable} ${sarabun.variable}`} nonce={nonce}>
-        <LIFFProvider>{children}</LIFFProvider>
+        <LIFFProvider><main>{children}</main></LIFFProvider>
       </body>
     </html>
   );

--- a/components/BookFairReminderModal.tsx
+++ b/components/BookFairReminderModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
 import { X } from "lucide-react";
 
 const DISMISSED_KEY = "bookfair_reminder_dismissed";
@@ -13,66 +14,67 @@ interface Props {
 export default function BookFairReminderModal({ isOpen, onClose }: Props) {
   const [dontShowAgain, setDontShowAgain] = useState(false);
 
-  if (!isOpen) return null;
-
   function handleConfirm() {
     if (dontShowAgain) localStorage.setItem(DISMISSED_KEY, "1");
     onClose();
   }
 
   return (
-    <div className="absolute inset-0 z-40 bg-black/70 flex items-center justify-center px-[16px]">
-      <div className="bg-[#fafaf8] rounded-[16px] p-[24px] w-full flex flex-col gap-[32px] items-center">
-        {/* Image + close */}
-        <div className="flex flex-col gap-[8px] items-center w-full">
-          <div className="flex justify-end w-full">
-            <button onClick={onClose} className="active:opacity-60 transition-opacity">
-              <X size={24} color="#3d2b1a" strokeWidth={1.5} />
-            </button>
-          </div>
-          <img
-            src="/bb-reminder.png"
-            alt="BB mascot"
-            className="size-[180px] rounded-[40px] object-cover"
-          />
-        </div>
-
-        {/* Text */}
-        <div className="flex flex-col gap-[16px] text-center text-[#3d2b1a] w-full">
-          <p className="font-[family-name:var(--font-sarabun)] font-semibold text-[24px] leading-tight">
-            อย่าลืม screenshot หน้าแผนที่ก่อนไปงานนะ
-          </p>
-          <p className="font-[family-name:var(--font-sarabun)] font-normal text-[16px] leading-normal whitespace-pre-line">
-            {`เนื่องจากในวันงานอาจมีคนใช้งานเยอะแล้วระบบเราไม่สามารถรองรับจำนวนคนได้ น้อง BB เลยอยากแนะนำให้ screenshot หน้าจอเก็บไว้ด้วยนะครับ จะได้หาบูธที่อยากไปเจอ\n\nเที่ยวงานหนังสือให้สนุกนะคร้าบบบ 🤎`}
-          </p>
-        </div>
-
-        {/* Actions */}
-        <div className="flex flex-col gap-[16px] w-full">
-          <button
-            onClick={handleConfirm}
-            className="h-[56px] w-full rounded-[16px] bg-[#c4855a] shadow-[2px_2px_0px_0px_#e0d0c0] active:scale-95 transition-all"
-          >
-            <span className="font-[family-name:var(--font-sarabun)] font-medium text-[20px] text-[#fafaf8]">
-              เข้าใจแล้ว
-            </span>
-          </button>
-
-          <label className="flex items-center gap-[12px] cursor-pointer">
-            <div className="flex items-center justify-center size-[20px]">
-              <input
-                type="checkbox"
-                checked={dontShowAgain}
-                onChange={(e) => setDontShowAgain(e.target.checked)}
-                className="size-[16px] rounded-[4px] border border-[#e4e4e7] accent-[#c4855a] cursor-pointer"
-              />
+    <Dialog open={isOpen} onClose={onClose} className="relative z-40">
+      <DialogBackdrop className="fixed inset-0 bg-black/70" />
+      <div className="fixed inset-0 flex items-center justify-center px-[16px]">
+        <DialogPanel className="bg-[#fafaf8] rounded-[16px] p-[24px] w-full flex flex-col gap-[32px] items-center">
+          {/* Image + close */}
+          <div className="flex flex-col gap-[8px] items-center w-full">
+            <div className="flex justify-end w-full">
+              <button onClick={onClose} aria-label="ปิด" className="active:opacity-60 transition-opacity">
+                <X size={24} color="#3d2b1a" strokeWidth={1.5} />
+              </button>
             </div>
-            <span className="font-[family-name:var(--font-sarabun)] text-[14px] text-[#3d2b1a] leading-[20px]">
-              ไม่ต้องแสดงข้อความให้เห็นอีก
-            </span>
-          </label>
-        </div>
+            <img
+              src="/bb-reminder.png"
+              alt="BB mascot"
+              className="size-[180px] rounded-[40px] object-cover"
+            />
+          </div>
+
+          {/* Text */}
+          <div className="flex flex-col gap-[16px] text-center text-[#3d2b1a] w-full">
+            <p className="font-[family-name:var(--font-sarabun)] font-semibold text-[24px] leading-tight">
+              อย่าลืม screenshot หน้าแผนที่ก่อนไปงานนะ
+            </p>
+            <p className="font-[family-name:var(--font-sarabun)] font-normal text-[16px] leading-normal whitespace-pre-line">
+              {`เนื่องจากในวันงานอาจมีคนใช้งานเยอะแล้วระบบเราไม่สามารถรองรับจำนวนคนได้ น้อง BB เลยอยากแนะนำให้ screenshot หน้าจอเก็บไว้ด้วยนะครับ จะได้หาบูธที่อยากไปเจอ\n\nเที่ยวงานหนังสือให้สนุกนะคร้าบบบ 🤎`}
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-col gap-[16px] w-full">
+            <button
+              onClick={handleConfirm}
+              className="h-[56px] w-full rounded-[16px] bg-[#c4855a] shadow-[2px_2px_0px_0px_#e0d0c0] active:scale-95 transition-all"
+            >
+              <span className="font-[family-name:var(--font-sarabun)] font-medium text-[20px] text-[#fafaf8]">
+                เข้าใจแล้ว
+              </span>
+            </button>
+
+            <label className="flex items-center gap-[12px] cursor-pointer">
+              <div className="flex items-center justify-center size-[20px]">
+                <input
+                  type="checkbox"
+                  checked={dontShowAgain}
+                  onChange={(e) => setDontShowAgain(e.target.checked)}
+                  className="size-[16px] rounded-[4px] border border-[#e4e4e7] accent-[#c4855a] cursor-pointer"
+                />
+              </div>
+              <span className="font-[family-name:var(--font-sarabun)] text-[14px] text-[#3d2b1a] leading-[20px]">
+                ไม่ต้องแสดงข้อความให้เห็นอีก
+              </span>
+            </label>
+          </div>
+        </DialogPanel>
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/components/BookFairReminderModal.tsx
+++ b/components/BookFairReminderModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 import { X } from "lucide-react";
 
 const DISMISSED_KEY = "bookfair_reminder_dismissed";
@@ -40,9 +40,9 @@ export default function BookFairReminderModal({ isOpen, onClose }: Props) {
 
           {/* Text */}
           <div className="flex flex-col gap-[16px] text-center text-[#3d2b1a] w-full">
-            <p className="font-[family-name:var(--font-sarabun)] font-semibold text-[24px] leading-tight">
+            <DialogTitle className="font-[family-name:var(--font-sarabun)] font-semibold text-[24px] leading-tight">
               อย่าลืม screenshot หน้าแผนที่ก่อนไปงานนะ
-            </p>
+            </DialogTitle>
             <p className="font-[family-name:var(--font-sarabun)] font-normal text-[16px] leading-normal whitespace-pre-line">
               {`เนื่องจากในวันงานอาจมีคนใช้งานเยอะแล้วระบบเราไม่สามารถรองรับจำนวนคนได้ น้อง BB เลยอยากแนะนำให้ screenshot หน้าจอเก็บไว้ด้วยนะครับ จะได้หาบูธที่อยากไปเจอ\n\nเที่ยวงานหนังสือให้สนุกนะคร้าบบบ 🤎`}
             </p>

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -32,7 +32,7 @@ export default memo(function BottomNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="shrink-0 border-t border-[#f0e4d4] bg-[#fafaf8]">
+    <nav aria-label="เมนูหลัก" className="shrink-0 border-t border-[#f0e4d4] bg-[#fafaf8]">
       <div className="flex pt-[8px] px-[24px] justify-between" style={{ paddingBottom: "calc(12px + var(--sab))" }}>
         {tabs.map((tab) => {
           const active = pathname === tab.href;
@@ -40,6 +40,7 @@ export default memo(function BottomNav() {
             <Link
               key={tab.href}
               href={tab.href}
+              aria-current={active ? "page" : undefined}
               className="flex flex-col items-center gap-[8px] w-[80px]"
             >
               {tab.icon(active)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "thai-book-buddy",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.9",
         "@line/liff": "2.27.3",
         "@supabase/supabase-js": "^2.98.0",
         "lucide-react": "^0.577.0",
@@ -457,6 +458,79 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
+      "integrity": "sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2053,6 +2127,103 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.5.tgz",
+      "integrity": "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.1.tgz",
+      "integrity": "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
+      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.1.tgz",
+      "integrity": "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2418,6 +2589,33 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -3559,6 +3757,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -7154,6 +7361,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -7518,6 +7731,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.9",
     "@line/liff": "2.27.3",
     "@supabase/supabase-js": "^2.98.0",
     "lucide-react": "^0.577.0",


### PR DESCRIPTION
## Summary
- Convert 3 modals to Headless UI `<Dialog>` with focus traps, Escape key, and proper `role="dialog"` / `aria-modal` semantics
  - BookFairReminderModal
  - Browse page delete confirmation
  - Admin publisher detail modal
- Add ARIA attributes across interactive elements:
  - `aria-label` on BottomNav, `aria-current="page"` on active tab
  - `role="tablist"` / `role="tab"` / `aria-selected` on browse zone filters
  - `aria-sort` on admin sortable table headers
  - `aria-label="ปิด"` on all modal close buttons
- Add `<main>` landmark to root layout
- New dependency: `@headlessui/react`

**Lighthouse accessibility score: 90/94 → 96 on browse/map pages**

Closes #35
Closes #36

## Test plan
- [ ] Browse page: open reminder modal → Escape key closes it, Tab cycles within modal
- [ ] Browse page: open delete confirmation → Escape key closes it, focus trapped
- [ ] Admin page: click publisher row → detail modal opens with focus trap, Escape closes
- [ ] BottomNav: active tab has `aria-current="page"` (inspect in DevTools)
- [ ] Browse filters: buttons have `role="tab"` and `aria-selected` (inspect in DevTools)
- [ ] Admin table: headers show `aria-sort` when sorted (inspect in DevTools)
- [ ] Lighthouse accessibility audit ≥ 95 on `/browse` and `/map`