### PR TITLE
feat: share brag card from my-list page

### DIFF
--- a/app/my-list/page.tsx
+++ b/app/my-list/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Trash2, HandHeart } from "lucide-react";
+import { Trash2, HandHeart, Share2 } from "lucide-react";
+import ShareCard from "../../components/ShareCard";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { getSupabase } from "../../utils/supabase";
@@ -34,6 +35,9 @@ export default function MyListPage() {
     () => process.env.NEXT_PUBLIC_DONATE_BANNER_ENABLED === "true" &&
           typeof window !== "undefined" && !sessionStorage.getItem("donate_banner_dismissed")
   );
+  const [shareStats, setShareStats] = useState<{ purchasedCount: number; percentile: number; totalSpent: number; boothCount: number } | null>(null);
+  const [sharing, setSharing] = useState(false);
+  const shareCardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     return () => {
@@ -248,6 +252,47 @@ export default function MyListPage() {
     }
   }
 
+  const purchasedCount = useMemo(() => books.filter((b) => b.is_purchased).length, [books]);
+
+  async function handleShare() {
+    if (sharing) return;
+    setSharing(true);
+    try {
+      const supabase = getSupabase();
+      const { data, error } = await supabase.rpc("get_share_stats");
+      if (error || !data || data.length === 0) throw new Error("Failed to load stats");
+      const stats = data[0] as { purchased_count: number; percentile: number; total_spent: number; booth_count: number };
+      setShareStats({
+        purchasedCount: Number(stats.purchased_count),
+        percentile: Number(stats.percentile),
+        totalSpent: Number(stats.total_spent),
+        boothCount: Number(stats.booth_count),
+      });
+      // Wait for React to render the ShareCard
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const html2canvas = (await import("html2canvas")).default;
+      if (!shareCardRef.current) throw new Error("Card not rendered");
+      const canvas = await html2canvas(shareCardRef.current, {
+        scale: 1,
+        useCORS: true,
+        backgroundColor: "#fafaf8",
+        width: 1080,
+        height: 1920,
+      });
+      const link = document.createElement("a");
+      link.download = "bookfair-buddy-stats.png";
+      link.href = canvas.toDataURL("image/png");
+      link.click();
+    } catch {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      setToast({ message: "ไม่สามารถสร้างรูปได้ กรุณาลองใหม่", onUndo: null });
+      toastTimer.current = setTimeout(() => setToast(null), 3000);
+    } finally {
+      setSharing(false);
+      setShareStats(null);
+    }
+  }
+
   if (authLoading || loading) return <LoadingScreen />;
   if (loadError) return <ErrorScreen onRetry={() => { setLoadError(false); setLoading(true); setRetryKey((k) => k + 1); }} />;
 
@@ -289,6 +334,18 @@ export default function MyListPage() {
               </div>
             </div>
           </div>
+          {purchasedCount > 0 && (
+            <button
+              onClick={handleShare}
+              disabled={sharing}
+              className="flex items-center justify-center gap-[8px] h-[48px] w-full rounded-[16px] border border-[#e2c9a6] bg-[#fff8ee] active:scale-95 transition-all disabled:opacity-50"
+            >
+              <Share2 size={18} color="#c4855a" strokeWidth={2} />
+              <span className="font-[family-name:var(--font-sarabun)] font-medium text-[16px] text-[#c4855a]">
+                {sharing ? "กำลังสร้างรูป..." : "แชร์สถิติของฉัน"}
+              </span>
+            </button>
+          )}
         </div>
 
         {/* Sticky search + count row */}
@@ -389,6 +446,15 @@ export default function MyListPage() {
             )}
           </div>
         </div>
+      )}
+      {shareStats && (
+        <ShareCard
+          ref={shareCardRef}
+          purchasedCount={shareStats.purchasedCount}
+          percentile={shareStats.percentile}
+          totalSpent={shareStats.totalSpent}
+          boothCount={shareStats.boothCount}
+        />
       )}
       <BottomNav />
     </div>

--- a/components/ShareCard.tsx
+++ b/components/ShareCard.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { forwardRef } from "react";
+
+interface ShareCardProps {
+  purchasedCount: number;
+  percentile: number;
+  totalSpent: number;
+  boothCount: number;
+}
+
+const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(
+  function ShareCard({ purchasedCount, percentile, totalSpent, boothCount }, ref) {
+    return (
+      <div
+        ref={ref}
+        style={{
+          width: 1080,
+          height: 1920,
+          background: "#fafaf8",
+          padding: "120px 90px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          fontFamily: "sans-serif",
+          position: "absolute",
+          left: "-9999px",
+          top: 0,
+        }}
+      >
+        {/* Header with mascot */}
+        <div style={{ display: "flex", alignItems: "center", gap: "36px" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/mascot.png"
+            alt="BB mascot"
+            style={{
+              width: 180,
+              height: 180,
+              borderRadius: 48,
+              objectFit: "cover",
+            }}
+          />
+          <div>
+            <div
+              style={{
+                fontSize: 48,
+                fontWeight: 700,
+                color: "#3d2b1a",
+              }}
+            >
+              BookFair Buddy
+            </div>
+            <div
+              style={{
+                fontSize: 36,
+                color: "#9c7a5b",
+                marginTop: 8,
+              }}
+            >
+              งานสัปดาห์หนังสือ 2569
+            </div>
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div style={{ textAlign: "center" }}>
+          <div
+            style={{
+              fontSize: 256,
+              fontWeight: 900,
+              color: "#c4855a",
+              lineHeight: 1,
+            }}
+          >
+            {purchasedCount}
+          </div>
+          <div
+            style={{
+              fontSize: 56,
+              color: "#3d2b1a",
+              marginTop: 16,
+              fontWeight: 600,
+            }}
+          >
+            เล่มที่ซื้อแล้ว
+          </div>
+
+          {/* Percentile badge */}
+          <div
+            style={{
+              marginTop: 80,
+              background: "#f3ffeb",
+              borderRadius: 48,
+              padding: "48px 64px",
+              border: "4px solid #c4d8b6",
+            }}
+          >
+            <div style={{ fontSize: 44, color: "#9c7a5b" }}>
+              ซื้อหนังสือมากกว่า
+            </div>
+            <div
+              style={{
+                fontSize: 112,
+                fontWeight: 800,
+                color: "#973c00",
+              }}
+            >
+              {percentile}%
+            </div>
+            <div style={{ fontSize: 44, color: "#9c7a5b" }}>
+              ของผู้ใช้ทั้งหมด
+            </div>
+          </div>
+
+          {/* Secondary stats */}
+          <div
+            style={{
+              marginTop: 64,
+              display: "flex",
+              justifyContent: "center",
+              gap: 64,
+            }}
+          >
+            <div style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  fontSize: 80,
+                  fontWeight: 700,
+                  color: "#3d2b1a",
+                }}
+              >
+                {boothCount}
+              </div>
+              <div style={{ fontSize: 36, color: "#9c7a5b" }}>บูธ</div>
+            </div>
+            <div
+              style={{
+                width: 4,
+                height: 120,
+                background: "#e2c9a6",
+                alignSelf: "center",
+              }}
+            />
+            <div style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  fontSize: 80,
+                  fontWeight: 700,
+                  color: "#3d2b1a",
+                }}
+              >
+                ฿{totalSpent.toLocaleString()}
+              </div>
+              <div style={{ fontSize: 36, color: "#9c7a5b" }}>รวมทั้งหมด</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 36, color: "#a6a09b" }}>
+            แชร์จาก BookFair Buddy
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+export default ShareCard;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@line/liff": "2.27.3",
         "@supabase/supabase-js": "^2.98.0",
+        "html2canvas": "^1.4.1",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -3386,6 +3387,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -3620,6 +3630,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -4941,6 +4960,19 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -7175,6 +7207,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tiny-sha256": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tiny-sha256/-/tiny-sha256-1.0.2.tgz",
@@ -7518,6 +7559,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@line/liff": "2.27.3",
     "@supabase/supabase-js": "^2.98.0",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/supabase/migrations/20260404000002_add_share_stats_rpc.sql
+++ b/supabase/migrations/20260404000002_add_share_stats_rpc.sql
@@ -1,0 +1,54 @@
+-- Returns share card stats for the current user:
+-- purchased_count, percentile (0-100), total_spent, booth_count
+create or replace function get_share_stats()
+returns table(
+  purchased_count bigint,
+  percentile integer,
+  total_spent bigint,
+  booth_count bigint
+)
+language sql
+security invoker
+stable
+as $$
+  with user_counts as (
+    select
+      ub.user_id,
+      count(*) as cnt
+    from user_books ub
+    where ub.is_purchased = true
+    group by ub.user_id
+  ),
+  ranked as (
+    select
+      user_id,
+      cnt,
+      percent_rank() over (order by cnt) as pct
+    from user_counts
+  ),
+  my_rank as (
+    select
+      coalesce(cnt, 0) as purchased_count,
+      coalesce((pct * 100)::integer, 0) as percentile
+    from ranked
+    where user_id = auth.uid()
+  ),
+  my_spent as (
+    select coalesce(sum(price), 0) as total_spent
+    from user_books
+    where user_id = auth.uid() and is_purchased = true
+  ),
+  my_booths as (
+    select count(*) as booth_count
+    from user_selections
+    where user_id = auth.uid()
+  )
+  select
+    coalesce(r.purchased_count, 0),
+    coalesce(r.percentile, 0),
+    s.total_spent,
+    b.booth_count
+  from my_spent s
+  cross join my_booths b
+  left join my_rank r on true;
+$$;


### PR DESCRIPTION
## Summary
- Add "แชร์สถิติของฉัน" button to my-list page that generates a brag card image
- New Supabase RPC `get_share_stats` calculates purchased book count, percentile rank (`percent_rank()`), total spent, and booth count
- New `ShareCard` component renders an Instagram Story-sized card (1080x1920) with BB mascot, stats, and percentile badge
- Uses `html2canvas` to capture the card as a downloadable PNG
- Share button only visible when user has at least 1 purchased book

## New dependencies
- `html2canvas` — client-side HTML-to-canvas rendering

## New migration
- `20260404000002_add_share_stats_rpc.sql` — needs `supabase db push` to deploy

## Test plan
- [ ] Share button appears only when `is_purchased = true` books exist
- [ ] Tapping button shows "กำลังสร้างรูป..." loading state
- [ ] PNG downloads with correct 1080x1920 dimensions
- [ ] Card shows correct purchased count, percentile, booth count, and total spent
- [ ] BB mascot renders in the card image
- [ ] Error toast shown if stats fetch fails